### PR TITLE
docs: restructure documentation with detailed guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,3 @@ next-env.d.ts
 # SpecStory explanation file
 .specstory/.what-is-this.md
 
-# Documentation (project-specific development docs)
-/docs

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -1,0 +1,314 @@
+# Coding Standards
+
+## TypeScript Guidelines
+
+### 基本設定
+- Strict modeを有効化
+- 明示的な型定義を推奨
+- `any`型の使用は原則禁止
+
+### 型定義のベストプラクティス
+```typescript
+// Good: 明示的な型定義
+interface VideoProps {
+  id: string;
+  title: string;
+  thumbnailUrl: string;
+  viewCount: number;
+}
+
+// Bad: 暗黙的なany
+function processVideo(video) { // ❌
+  return video.title;
+}
+
+// Good: 適切な型付け
+function processVideo(video: VideoProps): string { // ✅
+  return video.title;
+}
+```
+
+### 型の配置
+- コンポーネント固有の型: 同じファイル内で定義
+- 共有される型: `/src/types/`に配置
+- APIレスポンス型: `/src/types/api.ts`
+- データベース型: Prismaが自動生成
+
+## React/Next.js Patterns
+
+### Server Components vs Client Components
+
+#### Server Components (デフォルト)
+```typescript
+// src/app/dashboard/page.tsx
+import { getVideos } from '@/dal/videos';
+
+export default async function DashboardPage() {
+  const videos = await getVideos(); // サーバーサイドでデータ取得
+  
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <VideoList videos={videos} />
+    </div>
+  );
+}
+```
+
+#### Client Components
+```typescript
+// src/components/features/videos/video-card.tsx
+"use client"; // 必須: クライアントコンポーネントの宣言
+
+import { useState } from 'react';
+
+export function VideoCard({ video }: { video: Video }) {
+  const [isLiked, setIsLiked] = useState(false);
+  
+  // インタラクティブな要素を含む
+  return (
+    <div onClick={() => setIsLiked(!isLiked)}>
+      {/* ... */}
+    </div>
+  );
+}
+```
+
+### コンポーネントの構造化
+```typescript
+// 1. Imports
+import { FC } from 'react';
+import { VideoProps } from '@/types';
+
+// 2. Type definitions (ローカル型のみ)
+interface LocalProps extends VideoProps {
+  onSelect?: (id: string) => void;
+}
+
+// 3. Component definition
+export const VideoCard: FC<LocalProps> = ({ 
+  title, 
+  thumbnailUrl,
+  onSelect 
+}) => {
+  // 4. Hooks
+  const [state, setState] = useState();
+  
+  // 5. Event handlers
+  const handleClick = () => {
+    onSelect?.(id);
+  };
+  
+  // 6. Render
+  return (
+    <div onClick={handleClick}>
+      {/* ... */}
+    </div>
+  );
+};
+```
+
+## Data Access Layer (DAL)
+
+### DALパターンの実装
+```typescript
+// src/dal/videos.ts
+import { prisma } from '@/lib/database';
+import { Video } from '@prisma/client';
+
+// データ取得関数
+export async function getVideosByGenre(
+  genreIds: string[]
+): Promise<Video[]> {
+  return prisma.video.findMany({
+    where: {
+      genreId: { in: genreIds }
+    },
+    orderBy: { createdAt: 'desc' }
+  });
+}
+
+// データ更新関数
+export async function updateVideoViews(
+  videoId: string,
+  userId: string
+): Promise<void> {
+  await prisma.videoView.create({
+    data: { videoId, userId }
+  });
+}
+```
+
+### DAL使用ルール
+- ビジネスロジックとデータアクセスを分離
+- Prismaクライアントの直接使用は禁止
+- エラーハンドリングはDAL層で実装
+
+## Import Order
+
+インポートは以下の順序で整理：
+
+```typescript
+// 1. React/Next.js
+import { FC, useState } from 'react';
+import { notFound } from 'next/navigation';
+
+// 2. External libraries
+import { format } from 'date-fns';
+import { motion } from 'framer-motion';
+
+// 3. Internal - absolute imports
+import { Button } from '@/components/ui/button';
+import { getVideos } from '@/dal/videos';
+
+// 4. Internal - relative imports
+import { VideoCard } from './video-card';
+
+// 5. Types
+import type { Video } from '@/types';
+
+// 6. Styles (if any)
+import styles from './styles.module.css';
+```
+
+## ファイル・ディレクトリ命名規則
+
+### ファイル名
+- コンポーネント: `kebab-case.tsx` (例: `video-card.tsx`)
+- ユーティリティ: `camelCase.ts` (例: `formatDate.ts`)
+- 型定義: `camelCase.ts` (例: `videoTypes.ts`)
+
+### エクスポート
+- コンポーネント: PascalCase
+- 関数: camelCase
+- 定数: UPPER_SNAKE_CASE
+
+```typescript
+// video-card.tsx
+export const VideoCard = () => { };
+
+// utils.ts
+export const formatViewCount = (count: number) => { };
+
+// constants.ts
+export const MAX_VIDEO_LENGTH = 3600;
+```
+
+## スタイリング
+
+### Tailwind CSS使用規則
+```tsx
+// Good: Tailwindクラスの整理された使用
+<div className="flex flex-col gap-4 p-6 bg-white rounded-lg shadow-sm">
+  <h2 className="text-2xl font-bold text-gray-900">Title</h2>
+  <p className="text-base text-gray-600">Description</p>
+</div>
+
+// Bad: インラインスタイル
+<div style={{ display: 'flex', padding: '24px' }}>
+```
+
+### レスポンシブデザイン
+```tsx
+// モバイルファーストアプローチ
+<div className="p-4 md:p-6 lg:p-8">
+  <h1 className="text-xl md:text-2xl lg:text-3xl">
+    Responsive Title
+  </h1>
+</div>
+```
+
+## エラーハンドリング
+
+### Server Components
+```typescript
+// src/app/videos/[id]/page.tsx
+export default async function VideoPage({ 
+  params 
+}: { 
+  params: { id: string } 
+}) {
+  const video = await getVideo(params.id);
+  
+  if (!video) {
+    notFound(); // 404ページへ
+  }
+  
+  return <VideoDetail video={video} />;
+}
+```
+
+### Client Components
+```typescript
+"use client";
+
+export function VideoPlayer({ videoId }: { videoId: string }) {
+  const [error, setError] = useState<Error | null>(null);
+  
+  if (error) {
+    return <ErrorBoundary error={error} />;
+  }
+  
+  // ...
+}
+```
+
+## パフォーマンス最適化
+
+### 画像の最適化
+```tsx
+import Image from 'next/image';
+
+// Next.js Image componentを使用
+<Image
+  src={thumbnailUrl}
+  alt={title}
+  width={320}
+  height={180}
+  className="rounded-lg"
+  loading="lazy"
+/>
+```
+
+### データフェッチングの最適化
+```typescript
+// 並列フェッチング
+export default async function DashboardPage() {
+  // Promise.allで並列実行
+  const [user, videos, trends] = await Promise.all([
+    getCurrentUser(),
+    getRecommendedVideos(),
+    getTrendingVideos()
+  ]);
+  
+  return <Dashboard user={user} videos={videos} trends={trends} />;
+}
+```
+
+## セキュリティ
+
+### 環境変数の取り扱い
+```typescript
+// Good: サーバーサイドのみで使用
+const apiKey = process.env.YOUTUBE_API_KEY; // サーバーコンポーネント内
+
+// Bad: クライアントに露出
+const apiKey = process.env.NEXT_PUBLIC_API_KEY; // 注意が必要
+```
+
+### ユーザー入力の検証
+```typescript
+// Zodを使用した検証例
+import { z } from 'zod';
+
+const videoSchema = z.object({
+  title: z.string().min(1).max(100),
+  description: z.string().max(500),
+  genreId: z.string().uuid()
+});
+
+export async function createVideo(input: unknown) {
+  const validated = videoSchema.parse(input);
+  // ...
+}
+```

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -1,0 +1,121 @@
+# Project Overview
+
+## Yuumil - Video Discovery Platform
+
+Yuumilは、パーソナライズされた動画フィードとトレンドコンテンツを提供する動画発見・推薦プラットフォームです。
+
+## Technology Stack
+
+### Core Technologies
+- **Framework**: Next.js 15.3.2 (App Router)
+- **Language**: TypeScript (Strict Mode)
+- **Runtime**: Node.js with Turbopack
+
+### Frontend
+- **UI Library**: React 19
+- **Component Library**: Radix UI primitives
+- **Styling**: Tailwind CSS with Typography plugin
+- **Animations**: Framer Motion
+- **Icons**: Lucide React
+
+### Backend & Data
+- **Authentication**: Clerk
+- **Database**: Supabase (PostgreSQL)
+- **ORM**: Prisma
+- **API**: YouTube Data API v3
+- **Data Fetching**: SWR
+
+## Architecture
+
+### Directory Structure
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── (marketing)/       # Marketing pages group
+│   ├── api/               # API routes
+│   ├── dashboard/         # Protected dashboard
+│   ├── onboarding/        # User onboarding flow
+│   ├── profile/           # User profile
+│   └── trends/            # Trending content
+├── components/            # React components
+│   ├── common/           # Shared components
+│   ├── features/         # Feature-specific components
+│   ├── forms/            # Form components
+│   ├── layout/           # Layout components
+│   ├── marketing/        # Marketing components
+│   └── ui/               # Base UI primitives
+├── dal/                   # Data Access Layer
+├── lib/                   # Utilities and configurations
+└── types/                 # TypeScript definitions
+```
+
+### Key Design Patterns
+
+#### 1. Server Components by Default
+Next.js 15のServer Componentsを活用し、サーバーサイドでのデータフェッチを基本とします。
+
+```typescript
+// Example: src/app/dashboard/page.tsx
+export default async function DashboardPage() {
+  const user = await currentUser();
+  const videos = await getVideosByGenres(user.preferences);
+  return <DashboardClient videos={videos} />;
+}
+```
+
+#### 2. Data Access Layer (DAL)
+すべてのデータベース操作は`/src/dal/`を通じて行い、ビジネスロジックとデータ層を分離します。
+
+```typescript
+// Good: DAL経由でのデータアクセス
+import { getVideosByGenres } from '@/dal/videos';
+
+// Bad: 直接Prismaを使用
+import { prisma } from '@/lib/db';
+```
+
+#### 3. Client/Server Component Split
+インタラクティブな要素はClient Componentとして分離し、`"use client"`ディレクティブを使用します。
+
+```typescript
+// Server Component (default)
+export default async function VideoList() {
+  const videos = await fetchVideos();
+  return <VideoGrid videos={videos} />;
+}
+
+// Client Component
+"use client"
+export function VideoCard({ video }: { video: Video }) {
+  const [liked, setLiked] = useState(false);
+  // Interactive logic
+}
+```
+
+## Database Schema
+
+### Main Tables
+- `users` - ユーザー情報（Clerkと同期）
+- `user_preferences` - ユーザーの好みとジャンル設定
+- `videos` - 動画メタデータ
+- `video_views` - 視聴履歴
+- `genres` - ジャンルマスタ
+
+## API Structure
+
+### Public APIs
+- `/api/health` - ヘルスチェック
+- `/api/auth/sync` - Clerkとのユーザー同期
+
+### Protected APIs
+- `/api/videos/trends` - トレンド動画の取得
+- `/api/videos/news` - ニュース動画の取得
+- `/api/tags` - タグ情報の取得
+
+## Environment Configuration
+
+詳細な環境変数設定については`env.example`を参照してください：
+- Supabase接続情報
+- Clerk認証キー
+- YouTube API設定
+- アプリケーション設定

--- a/docs/workflows/git-workflow.md
+++ b/docs/workflows/git-workflow.md
@@ -1,0 +1,161 @@
+# Git Workflow
+
+## Branch Strategy
+
+### Branch Types
+- **main** - プロダクションブランチ
+  - 常にデプロイ可能な状態を維持
+  - 直接のコミットは禁止
+  
+- **feature/<task-id>** - 機能開発
+  - 新機能や改善の実装
+  - mainブランチから作成
+  - 例: `feature/add-video-filter`, `feature/123-user-profile`
+  
+- **hotfix/<issue-id>** - 緊急修正
+  - プロダクションの重大なバグ修正
+  - mainブランチから作成
+  - 例: `hotfix/fix-auth-error`, `hotfix/456-payment-bug`
+
+## Commit Guidelines
+
+### Conventional Commits Format
+すべてのコミットメッセージはConventional Commits仕様に従います。
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Commit Types
+- **feat**: 新機能の追加
+- **fix**: バグ修正
+- **docs**: ドキュメントのみの変更
+- **style**: コードの意味に影響しない変更（空白、フォーマット等）
+- **refactor**: バグ修正や機能追加を伴わないコード変更
+- **perf**: パフォーマンス改善
+- **test**: テストの追加や修正
+- **chore**: ビルドプロセスやツールの変更
+
+### Examples
+```bash
+feat: add video filtering by genre
+fix: resolve authentication error on dashboard
+docs: update API documentation
+refactor: simplify video card component
+chore: update dependencies
+```
+
+### 日本語でのコミットメッセージ
+本文は日本語で記述可能です：
+
+```bash
+feat: ジャンル別の動画フィルタリング機能を追加
+
+ユーザーが好みのジャンルで動画を絞り込めるように
+フィルタリング機能を実装しました。
+```
+
+## Pull Request Process
+
+### 1. ブランチの作成とプッシュ
+```bash
+# featureブランチの作成
+git checkout -b feature/your-feature-name
+
+# 作業後、コミット
+git add .
+git commit -m "feat: add new feature"
+
+# リモートへプッシュ
+git push -u origin feature/your-feature-name
+```
+
+### 2. Pull Requestの作成
+**重要**: Claude Codeでは、コミット後に自動的にPRを作成します。
+
+```bash
+gh pr create --title "feat: タイトル" --body "詳細な説明"
+```
+
+### 3. PR Template
+```markdown
+## Summary
+- 変更の概要を箇条書きで記載
+
+## Changes
+- 具体的な変更内容
+- 影響範囲
+- 技術的な詳細
+
+## Test plan
+- [ ] 単体テストの実行
+- [ ] 統合テストの実行
+- [ ] 手動での動作確認
+- [ ] リグレッションテスト
+
+## Screenshots (if applicable)
+UIの変更がある場合はスクリーンショットを添付
+```
+
+### 4. マージ戦略
+- **Squash merge**を使用
+- マージ後は自動的にブランチを削除
+
+## Best Practices
+
+### 1. コミットの粒度
+- 1つのコミットは1つの論理的な変更に対応
+- コミットは独立してrevertできる単位に
+
+### 2. ブランチの管理
+- 長期間のブランチは避ける（最大1週間）
+- 定期的にmainブランチの変更を取り込む
+
+```bash
+# mainの最新を取り込む
+git checkout main
+git pull origin main
+git checkout feature/your-feature
+git merge main
+```
+
+### 3. コードレビュー
+- セルフレビューを実施
+- PR作成前にlintとtestを実行
+- レビュアーへのコンテキスト提供
+
+### 4. 自動化
+Claude Codeを使用する場合、以下が自動化されます：
+- ブランチ作成
+- コミットメッセージの生成
+- PR作成
+- リンクの提供
+
+## Troubleshooting
+
+### コンフリクトの解決
+```bash
+# mainの最新を取得
+git fetch origin main
+
+# マージ実行
+git merge origin/main
+
+# コンフリクトを解決後
+git add .
+git commit -m "fix: resolve merge conflicts"
+```
+
+### 誤ったコミットの修正
+```bash
+# 直前のコミットメッセージを修正
+git commit --amend -m "新しいメッセージ"
+
+# 直前のコミットに変更を追加
+git add .
+git commit --amend --no-edit
+```


### PR DESCRIPTION
## Summary
- ドキュメントを`docs/`ディレクトリに再構成
- CLAUDE.mdを軽量化してメインエントリーポイントに
- 詳細な情報を個別ファイルに分割

## Changes
- 📄 **CLAUDE.md** - 軽量化し、詳細ドキュメントへのリンクを追加
- 📁 **docs/**
  - 📄 `project-overview.md` - プロジェクト概要とアーキテクチャ詳細
  - 📄 `coding-standards.md` - コーディング規約とベストプラクティス
  - 📁 **workflows/**
    - 📄 `git-workflow.md` - 詳細なGitワークフローとPR手順
- 🔧 **.gitignore** - docs/を削除してドキュメントをコミット可能に

## Test plan
- [ ] CLAUDE.mdから各ドキュメントへのリンクが機能することを確認
- [ ] 各ドキュメントの内容が正しく表示されることを確認
- [ ] マークダウンの書式が正しくレンダリングされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)